### PR TITLE
Fix typo in link to next title

### DIFF
--- a/_pages/a-pairing-session-template.md
+++ b/_pages/a-pairing-session-template.md
@@ -117,6 +117,6 @@ Possible areas for improvement:
 include navigation-buttons.html 
 previous-title="Your First Pairing Session" 
 previous-url="/pair-programming-guide/your-first-pairing-session"
-next-title="Pair Programing Styles"
+next-title="Pair Programming Styles"
 next-url="/pair-programming-guide/styles"
 %}


### PR DESCRIPTION
Awesome guide! I spotted one typo in https://tuple.app/pair-programming-guide/template and figured I'd open a PR to fix that for you ☺️ 

![A_Pairing_Session_Template](https://user-images.githubusercontent.com/482561/77431732-c8ade780-6de5-11ea-86a7-d10ea67badee.png)
