### PR TITLE
Add missing word in Avoid definitive language

### DIFF
--- a/_pages/how-to-pair-with-a-junior-developer.md
+++ b/_pages/how-to-pair-with-a-junior-developer.md
@@ -64,7 +64,7 @@ Spend most of the session observing them patiently and share only the tip or two
 
 Don't say someone should "always" or "never" do something. Share the tradeoffs of each approach.
 
-Avoid justifying a decision by saying it's a best practice. Talk about the elements make it a good fit for your situation.
+Avoid justifying a decision by saying it's a best practice. Talk about the elements that make it a good fit for your situation.
 
 
 ## Ask questions


### PR DESCRIPTION
The sentence "Talk about the elements [that] make it a good fit for your situation." was missing a word. I fixed it for you! 

Thanks for this useful guide.